### PR TITLE
ascii_letters and digits contains only alphanumeric.

### DIFF
--- a/nhentai/utils.py
+++ b/nhentai/utils.py
@@ -199,8 +199,9 @@ and append a file extension like '.txt', so I avoid the potential of using
 an invalid filename.
 
 """
-    valid_chars = "-_.()[] %s%s" % (string.ascii_letters, string.digits)
-    filename = ''.join(c for c in s if c in valid_chars)
+    # valid_chars = "-_.()[] %s%s" % (string.ascii_letters, string.digits)
+    # filename = ''.join(c for c in s if c in valid_chars)
+    filename = s
     if len(filename) > 100:
         filename = filename[:100] + '...]'
 


### PR DESCRIPTION
Therefore, subtitles of non-alphanumeric characters (such as JP and CN) are invalid.