### PR TITLE
new options added [--artist, --character, --parody, --group]

### DIFF
--- a/nhentai/cmdline.py
+++ b/nhentai/cmdline.py
@@ -50,6 +50,10 @@ def cmd_parser():
     parser.add_option('--id', type='string', dest='id', action='store', help='doujinshi ids set, e.g. 1,2,3')
     parser.add_option('--search', '-s', type='string', dest='keyword', action='store', help='search doujinshi by keyword')
     parser.add_option('--tag', type='string', dest='tag', action='store', help='download doujinshi by tag')
+    parser.add_option('--artist', type='string', dest='artist', action='store', help='download doujinshi by artist')
+    parser.add_option('--character', type='string', dest='character', action='store', help='download doujinshi by character')
+    parser.add_option('--parody', type='string', dest='parody', action='store', help='download doujinshi by parody')
+    parser.add_option('--group', type='string', dest='group', action='store', help='download doujinshi by group')
     parser.add_option('--favorites', '-F', action='store_true', dest='favorites',
                       help='list or download your favorites.')
 
@@ -104,7 +108,8 @@ def cmd_parser():
         exit(0)
 
     if args.main_viewer and not args.id and not args.keyword and \
-            not args.tag and not args.favorites:
+            not args.tag and not args.artist and not args.character and \
+            not args.parody and not args.group and not args.favorites:
         generate_main_html()
         exit(0)
 
@@ -164,12 +169,14 @@ def cmd_parser():
             args.id = set(map(int, filter(lambda id_: id_.isdigit(), _)))
 
     if (args.is_download or args.is_show) and not args.id and not args.keyword and \
-            not args.tag and not args.favorites:
+            not args.tag and not args.artist and not args.character and \
+            not args.parody and not args.group and not args.favorites:
         logger.critical('Doujinshi id(s) are required for downloading')
         parser.print_help()
         exit(1)
 
-    if not args.keyword and not args.id and not args.tag and not args.favorites:
+    if not args.keyword and not args.id and not args.tag and not args.artist and \
+            not args.character and not args.parody and not args.group and not args.favorites:
         parser.print_help()
         exit(1)
 

--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -19,7 +19,7 @@ def main():
     options = cmd_parser()
     logger.info('Using mirror: {0}'.format(BASE_URL))
 
-    from nhentai.constant import PROXY 
+    from nhentai.constant import PROXY
     # constant.PROXY will be changed after cmd_parser()
     if PROXY != {}:
         logger.info('Using proxy: {0}'.format(PROXY))
@@ -41,6 +41,30 @@ def main():
 
     elif options.tag:
         doujinshis = tag_parser(options.tag, max_page=options.max_page)
+        print_doujinshi(doujinshis)
+        if options.is_download and doujinshis:
+            doujinshi_ids = map(lambda d: d['id'], doujinshis)
+
+    elif options.artist:
+        doujinshis = tag_parser(options.artist, max_page=options.max_page, index=1)
+        print_doujinshi(doujinshis)
+        if options.is_download and doujinshis:
+            doujinshi_ids = map(lambda d: d['id'], doujinshis)
+
+    elif options.character:
+        doujinshis = tag_parser(options.character, max_page=options.max_page, index=2)
+        print_doujinshi(doujinshis)
+        if options.is_download and doujinshis:
+            doujinshi_ids = map(lambda d: d['id'], doujinshis)
+
+    elif options.parody:
+        doujinshis = tag_parser(options.parody, max_page=options.max_page, index=3)
+        print_doujinshi(doujinshis)
+        if options.is_download and doujinshis:
+            doujinshi_ids = map(lambda d: d['id'], doujinshis)
+
+    elif options.group:
+        doujinshis = tag_parser(options.group, max_page=options.max_page, index=4)
         print_doujinshi(doujinshis)
         if options.is_download and doujinshis:
             doujinshi_ids = map(lambda d: d['id'], doujinshis)

--- a/nhentai/constant.py
+++ b/nhentai/constant.py
@@ -17,7 +17,12 @@ __api_suspended_SEARCH_URL = '%s/api/galleries/search' % BASE_URL
 DETAIL_URL = '%s/g' % BASE_URL
 SEARCH_URL = '%s/search/' % BASE_URL
 
-TAG_URL = '%s/tag' % BASE_URL
+TAG_URL = ['%s/tag' % BASE_URL,
+           '%s/artist' % BASE_URL,
+           '%s/character' % BASE_URL,
+           '%s/parody' % BASE_URL,
+           '%s/group' % BASE_URL]
+
 TAG_API_URL = '%s/api/galleries/tagged' % BASE_URL
 LOGIN_URL = '%s/login/' % BASE_URL
 CHALLENGE_URL = '%s/challenge' % BASE_URL

--- a/nhentai/parser.py
+++ b/nhentai/parser.py
@@ -198,12 +198,18 @@ def tag_parser(tag_name, max_page=1, index=0):
     result = []
     tag_name = tag_name.lower()
     tag_name = tag_name.replace(' ', '-')
+    if ',' in tag_name:
+        tag_name = tag_name.split(',')
 
     for p in range(1, max_page + 1):
         logger.debug('Fetching page {0} for doujinshi with tag \'{1}\''.format(p, tag_name))
-        response = request('get', url='%s/%s/?page=%d' % (constant.TAG_URL[index], tag_name, p)).content
-
-        result += _get_title_and_id(response)
+        if isinstance(tag_name, str):
+            response = request('get', url='%s/%s/?page=%d' % (constant.TAG_URL[index], tag_name, p)).content
+            result += _get_title_and_id(response)
+        else:
+            for i in tag_name:
+                response = request('get', url='%s/%s/?page=%d' % (constant.TAG_URL[index], i, p)).content
+                result += _get_title_and_id(response)
         if not result:
             logger.error('Cannot find doujinshi id of tag \'{0}\''.format(tag_name))
             return

--- a/nhentai/parser.py
+++ b/nhentai/parser.py
@@ -194,14 +194,14 @@ def print_doujinshi(doujinshi_list):
                 tabulate(tabular_data=doujinshi_list, headers=headers, tablefmt='rst'))
 
 
-def tag_parser(tag_name, max_page=1):
+def tag_parser(tag_name, max_page=1, index=0):
     result = []
     tag_name = tag_name.lower()
     tag_name = tag_name.replace(' ', '-')
 
     for p in range(1, max_page + 1):
         logger.debug('Fetching page {0} for doujinshi with tag \'{1}\''.format(p, tag_name))
-        response = request('get', url='%s/%s/?page=%d' % (constant.TAG_URL, tag_name, p)).content
+        response = request('get', url='%s/%s/?page=%d' % (constant.TAG_URL[index], tag_name, p)).content
 
         result += _get_title_and_id(response)
         if not result:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+d# coding: utf-8
 from __future__ import print_function, unicode_literals
 import sys
 import codecs


### PR DESCRIPTION
Added new options and now is possible multiple arguments in -tag --artist, --character, --parody, --group, separating by comma.

eg: --artist mdo-h,tamano kedama

EDIT:
Wondering if has a better approach for multiple arguments using optparse.OptionParser(?)
FeelsBad using `if ',' in tag_name: tag_name.split(';')`