### PR TITLE
add page_range option for favorites

### DIFF
--- a/nhentai/cmdline.py
+++ b/nhentai/cmdline.py
@@ -63,6 +63,8 @@ def cmd_parser():
                       help='page number of search results')
     parser.add_option('--max-page', type='int', dest='max_page', action='store', default=1,
                       help='The max page when recursive download tagged doujinshi')
+    parser.add_option('--page-range', type='string', dest='page_range', action='store',
+                      help='page range of favorites.  e.g. 1,2-5,14')
     parser.add_option('--sorting', dest='sorting', action='store', default='date',
                       help='sorting of doujinshi (date / popular)', choices=['date', 'popular'])
 

--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -35,7 +35,7 @@ def main():
         if not options.is_download:
             logger.warning('You do not specify --download option')
 
-        doujinshis = favorites_parser()
+        doujinshis = favorites_parser(options.page_range)
         print_doujinshi(doujinshis)
         if options.is_download and doujinshis:
             doujinshi_ids = [i['id'] for i in doujinshis]


### PR DESCRIPTION
I added "--page-range" option.
Its usage likes "1,4-10,12", which means "page 1, page 4 to 10 and page 12".

Now we can use page_range option for favorite doujinshis.
Maybe this option could also be used in the general search.