### PR TITLE
write ComicInfo.xml for CBZ files

### DIFF
--- a/nhentai/cmdline.py
+++ b/nhentai/cmdline.py
@@ -38,7 +38,7 @@ def banner():
 def cmd_parser():
     parser = OptionParser('\n  nhentai --search [keyword] --download'
                           '\n  NHENTAI=http://h.loli.club nhentai --id [ID ...]'
-                          '\n  nhentai --file [filename]'    
+                          '\n  nhentai --file [filename]'
                           '\n\nEnvironment Variable:\n'
                           '  NHENTAI                 nhentai mirror url')
     # operation options
@@ -95,6 +95,8 @@ def cmd_parser():
                       help='generate a main viewer contain all the doujin in the folder')
     parser.add_option('--cbz', '-C', dest='is_cbz', action='store_true',
                       help='generate Comic Book CBZ File')
+    parser.add_option('--comic-info', dest='write_comic_info', action='store_true',
+                      help='when generating Comic Book CBZ File, also write ComicInfo.xml')
     parser.add_option('--rm-origin-dir', dest='rm_origin_dir', action='store_true', default=False,
                       help='remove downloaded doujinshi dir when generated CBZ file.')
 

--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -28,6 +28,7 @@ def main():
     check_cookie()
 
     index = 0
+    index_value = None
     doujinshis = []
     doujinshi_ids = []
     doujinshi_list = []
@@ -43,18 +44,23 @@ def main():
 
     elif options.artist:
         index = 1
+        index_value = options.artist
 
     elif options.character:
         index = 2
+        index_value = options.character
 
     elif options.parody:
         index = 3
+        index_value = options.parody
 
     elif options.group:
         index = 4
+        index_value = options.group
 
     elif options.language:
         index = 5
+        index_value = options.language
 
     elif options.keyword:
         doujinshis = search_parser(options.keyword, sorting=options.sorting, page=options.page)
@@ -63,7 +69,7 @@ def main():
         doujinshi_ids = options.id
 
     if index:
-        doujinshis = tag_parser(options.language, max_page=options.max_page, index=index)
+        doujinshis = tag_parser(index_value, max_page=options.max_page, index=index)
 
     print_doujinshi(doujinshis)
     if options.is_download and doujinshis:

--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -109,7 +109,7 @@ def main():
             if not options.is_nohtml and not options.is_cbz:
                 generate_html(options.output_dir, doujinshi)
             elif options.is_cbz:
-                generate_cbz(options.output_dir, doujinshi, options.rm_origin_dir)
+                generate_cbz(options.output_dir, doujinshi, options.rm_origin_dir, options.write_comic_info)
 
         if options.main_viewer:
             generate_main_html(options.output_dir)

--- a/nhentai/utils.py
+++ b/nhentai/utils.py
@@ -168,10 +168,11 @@ def generate_main_html(output_dir='./'):
         logger.warning('Writing Main Viewer failed ({})'.format(str(e)))
 
 
-def generate_cbz(output_dir='.', doujinshi_obj=None, rm_origin_dir=False):
+def generate_cbz(output_dir='.', doujinshi_obj=None, rm_origin_dir=False, write_comic_info=False):
     if doujinshi_obj is not None:
         doujinshi_dir = os.path.join(output_dir, doujinshi_obj.filename)
-        serialize_comicxml(doujinshi_obj, doujinshi_dir)
+        if write_comic_info:
+            serialize_comicxml(doujinshi_obj, doujinshi_dir)
         cbz_filename = os.path.join(os.path.join(doujinshi_dir, '..'), '{}.cbz'.format(doujinshi_obj.filename))
     else:
         cbz_filename = './doujinshi.cbz'

--- a/nhentai/utils.py
+++ b/nhentai/utils.py
@@ -12,7 +12,7 @@ import sqlite3
 
 from nhentai import constant
 from nhentai.logger import logger
-from nhentai.serializer import serialize, set_js_database
+from nhentai.serializer import serialize_json, serialize_comicxml, set_js_database
 
 
 def request(method, url, **kwargs):
@@ -86,7 +86,7 @@ def generate_html(output_dir='.', doujinshi_obj=None):
     js = readfile('viewer/scripts.js')
 
     if doujinshi_obj is not None:
-        serialize(doujinshi_obj, doujinshi_dir)
+        serialize_json(doujinshi_obj, doujinshi_dir)
         name = doujinshi_obj.name
         if sys.version_info < (3, 0):
             name = doujinshi_obj.name.encode('utf-8')
@@ -102,9 +102,9 @@ def generate_html(output_dir='.', doujinshi_obj=None):
             with open(os.path.join(doujinshi_dir, 'index.html'), 'wb') as f:
                 f.write(data.encode('utf-8'))
 
-        logger.log(15, 'HTML Viewer has been write to \'{0}\''.format(os.path.join(doujinshi_dir, 'index.html')))
+        logger.log(15, 'HTML Viewer has been written to \'{0}\''.format(os.path.join(doujinshi_dir, 'index.html')))
     except Exception as e:
-        logger.warning('Writen HTML Viewer failed ({})'.format(str(e)))
+        logger.warning('Writing HTML Viewer failed ({})'.format(str(e)))
 
 
 def generate_main_html(output_dir='./'):
@@ -150,7 +150,7 @@ def generate_main_html(output_dir='./'):
 
         image_html += element.format(FOLDER=folder, IMAGE=image, TITLE=title)
     if image_html == '':
-        logger.warning('None index.html found, --gen-main paused.')
+        logger.warning('No index.html found, --gen-main paused.')
         return
     try:
         data = main.format(STYLES=css, SCRIPTS=js, PICTURE=image_html)
@@ -163,14 +163,15 @@ def generate_main_html(output_dir='./'):
         shutil.copy(os.path.dirname(__file__)+'/viewer/logo.png', './')
         set_js_database()
         logger.log(
-            15, 'Main Viewer has been write to \'{0}main.html\''.format(output_dir))
+            15, 'Main Viewer has been written to \'{0}main.html\''.format(output_dir))
     except Exception as e:
-        logger.warning('Writen Main Viewer failed ({})'.format(str(e)))
+        logger.warning('Writing Main Viewer failed ({})'.format(str(e)))
 
 
 def generate_cbz(output_dir='.', doujinshi_obj=None, rm_origin_dir=False):
     if doujinshi_obj is not None:
         doujinshi_dir = os.path.join(output_dir, doujinshi_obj.filename)
+        serialize_comicxml(doujinshi_obj, doujinshi_dir)
         cbz_filename = os.path.join(os.path.join(doujinshi_dir, '..'), '{}.cbz'.format(doujinshi_obj.filename))
     else:
         cbz_filename = './doujinshi.cbz'
@@ -188,7 +189,7 @@ def generate_cbz(output_dir='.', doujinshi_obj=None, rm_origin_dir=False):
     if rm_origin_dir:
         shutil.rmtree(doujinshi_dir, ignore_errors=True)
 
-    logger.log(15, 'Comic Book CBZ file has been write to \'{0}\''.format(doujinshi_dir))
+    logger.log(15, 'Comic Book CBZ file has been written to \'{0}\''.format(doujinshi_dir))
 
 
 def format_filename(s):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ BeautifulSoup4>=4.0.0
 threadpool>=1.2.7
 tabulate>=0.7.5
 future>=0.15.2
+iso8601 >= 0.1


### PR DESCRIPTION
ComicInfo.xml is a common format to embed metadata into CBZ files, originating from the ComicRack reader app.

It's basically a `ComicInfo.xml` with all the information written into the CBZ file.