### PR TITLE
Add PDF support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,8 +154,9 @@ Other options:
       --no-html             don't generate HTML after downloading
       --gen-main            generate a main viewer contain all the doujin in the folder
       -C, --cbz             generate Comic Book CBZ File
+      -P --pdf              generate PDF file
       --rm-origin-dir       remove downloaded doujinshi dir when generated CBZ
-                            file.
+                            or PDF file.
 
       # nHentai options
       --cookie=COOKIE       set cookie of nhentai to bypass Google recaptcha

--- a/nhentai/cmdline.py
+++ b/nhentai/cmdline.py
@@ -38,7 +38,7 @@ def banner():
 def cmd_parser():
     parser = OptionParser('\n  nhentai --search [keyword] --download'
                           '\n  NHENTAI=http://h.loli.club nhentai --id [ID ...]'
-                          '\n  nhentai --file [filename]'    
+                          '\n  nhentai --file [filename]'
                           '\n\nEnvironment Variable:\n'
                           '  NHENTAI                 nhentai mirror url')
     # operation options
@@ -87,8 +87,10 @@ def cmd_parser():
                       help='generate a main viewer contain all the doujin in the folder')
     parser.add_option('--cbz', '-C', dest='is_cbz', action='store_true',
                       help='generate Comic Book CBZ File')
+    parser.add_option('--pdf', '-P', dest='is_pdf', action='store_true',
+                      help='generate PDF file')
     parser.add_option('--rm-origin-dir', dest='rm_origin_dir', action='store_true', default=False,
-                      help='remove downloaded doujinshi dir when generated CBZ file.')
+                      help='remove downloaded doujinshi dir when generated CBZ or PDF file.')
 
     # nhentai options
     parser.add_option('--cookie', type='str', dest='cookie', action='store',

--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -11,7 +11,7 @@ from nhentai.doujinshi import Doujinshi
 from nhentai.downloader import Downloader
 from nhentai.logger import logger
 from nhentai.constant import BASE_URL
-from nhentai.utils import generate_html, generate_cbz, generate_main_html, check_cookie, signal_handler, DB
+from nhentai.utils import generate_html, generate_cbz, generate_main_html, generate_pdf, check_cookie, signal_handler, DB
 
 
 def main():
@@ -82,10 +82,12 @@ def main():
                 with DB() as db:
                     db.add_one(doujinshi.id)
 
-            if not options.is_nohtml and not options.is_cbz:
+            if not options.is_nohtml and not options.is_cbz and not options.is_pdf:
                 generate_html(options.output_dir, doujinshi)
             elif options.is_cbz:
                 generate_cbz(options.output_dir, doujinshi, options.rm_origin_dir)
+            elif options.is_pdf:
+                generate_pdf(options.output_dir, doujinshi, options.rm_origin_dir)
 
         if options.main_viewer:
             generate_main_html(options.output_dir)

--- a/nhentai/utils.py
+++ b/nhentai/utils.py
@@ -9,6 +9,7 @@ import zipfile
 import shutil
 import requests
 import sqlite3
+import img2pdf
 
 from nhentai import constant
 from nhentai.logger import logger
@@ -191,6 +192,34 @@ def generate_cbz(output_dir='.', doujinshi_obj=None, rm_origin_dir=False, write_
         shutil.rmtree(doujinshi_dir, ignore_errors=True)
 
     logger.log(15, 'Comic Book CBZ file has been written to \'{0}\''.format(doujinshi_dir))
+
+
+def generate_pdf(output_dir='.', doujinshi_obj=None, rm_origin_dir=False):
+    """Write images to a PDF file using img2pdf."""
+    if doujinshi_obj is not None:
+        doujinshi_dir = os.path.join(output_dir, doujinshi_obj.filename)
+        pdf_filename = os.path.join(
+            os.path.join(doujinshi_dir, '..'),
+            '{}.pdf'.format(doujinshi_obj.filename)
+        )
+    else:
+        pdf_filename = './doujinshi.pdf'
+        doujinshi_dir = '.'
+
+    file_list = os.listdir(doujinshi_dir)
+    file_list.sort()
+
+    logger.info('Writing PDF file to path: {}'.format(pdf_filename))
+    with open(pdf_filename, 'wb') as pdf_f:
+        full_path_list = (
+            [os.path.join(doujinshi_dir, image) for image in file_list]
+        )
+        pdf_f.write(img2pdf.convert(full_path_list))
+
+    if rm_origin_dir:
+        shutil.rmtree(doujinshi_dir, ignore_errors=True)
+
+    logger.log(15, 'PDF file has been written to \'{0}\''.format(doujinshi_dir))
 
 
 def format_filename(s):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ BeautifulSoup4>=4.0.0
 threadpool>=1.2.7
 tabulate>=0.7.5
 future>=0.15.2
+img2pdf>=0.3.6
 iso8601 >= 0.1


### PR DESCRIPTION
Add support for converting to PDF by including a generate_pdf method that utilizes `img2pdf` python module and the relating command line options and documentation. 

Relates to issue #120 