### PR TITLE
remove args.tag since no tag option in parser

### DIFF
--- a/nhentai/cmdline.py
+++ b/nhentai/cmdline.py
@@ -116,8 +116,7 @@ def cmd_parser():
         generate_html()
         exit(0)
 
-    if args.main_viewer and not args.id and not args.keyword and \
-            not args.tag and not args.favorites:
+    if args.main_viewer and not args.id and not args.keyword and not args.favorites:
         generate_main_html()
         exit(0)
 
@@ -203,8 +202,7 @@ def cmd_parser():
             _ = [i.strip() for i in f.readlines()]
             args.id = set(int(i) for i in _ if i.isdigit())
 
-    if (args.is_download or args.is_show) and not args.id and not args.keyword and \
-            not args.tag and not args.favorites:
+    if (args.is_download or args.is_show) and not args.id and not args.keyword and not args.favorites:
         logger.critical('Doujinshi id(s) are required for downloading')
         parser.print_help()
         exit(1)


### PR DESCRIPTION
Or it will cause an AttributeError:

Traceback (most recent call last):                                                        
  File "/home/yunze/.local/bin/nhentai", line 11, in <module>                             
    load_entry_point('nhentai==0.3.9', 'console_scripts', 'nhentai')()                    
  File "/home/yunze/.local/lib/python3.8/site-packages/nhentai-0.3.9-py3.8.egg/nhentai/com
mand.py", line 19, in main                                                                
    options = cmd_parser()                                                                
  File "/home/yunze/.local/lib/python3.8/site-packages/nhentai-0.3.9-py3.8.egg/nhentai/cmd
line.py", line 207, in cmd_parser                                                         
    not args.tag and not args.favorites:                                                  
AttributeError: 'Values' object has no attribute 'tag'