### PR TITLE
Added to '-S --show' option, the 'Parodies' output

### DIFF
--- a/nhentai/__init__.py
+++ b/nhentai/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.4.2'
+__version__ = '0.4.3'
 __author__ = 'RicterZ'
 __email__ = 'ricterzheng@gmail.com'

--- a/nhentai/doujinshi.py
+++ b/nhentai/doujinshi.py
@@ -48,6 +48,7 @@ class Doujinshi(object):
 
     def show(self):
         table = [
+            ["Parodies", self.info.parodies],
             ["Doujinshi", self.name],
             ["Subtitle", self.info.subtitle],
             ["Characters", self.info.characters],


### PR DESCRIPTION
For some reason, on **-S --show** option, _**Parodies**_ wasn't added to the output.

Now, 
the output from **nhentai --id 331317 -S** 
```
[11:26:02] [INFO] Print doujinshi information of 331317
----------  ------------------------------------------------------------------------------
Parodies    kanojo okarishimasu | rent-a-girlfriend
Doujinshi   [AMP (Norakuro Nero)] Kanojo, Otoshimasu (Kanojo, Okarishimasu)
Subtitle    [AMP (野良黒ネロ)] 彼女、堕とします (彼女、お借りします)
Characters  sumi sakurasawa
Authors     norakuro nero
Languages   japanese
Tags        sole female, stockings, sole male, schoolgirl uniform, dilf, bbm, mind control
URL         https://nhentai.net/g/331317
Pages       22
----------  ------------------------------------------------------------------------------
```