### PR TITLE
Switching 'logger.warn' to 'logger.warning'

### DIFF
--- a/nhentai/downloader.py
+++ b/nhentai/downloader.py
@@ -119,14 +119,14 @@ class Downloader(Singleton):
             folder = os.path.join(self.path, folder)
 
         if not os.path.exists(folder):
-            logger.warn('Path \'{0}\' does not exist, creating.'.format(folder))
+            logger.warning('Path \'{0}\' does not exist, creating.'.format(folder))
             try:
                 os.makedirs(folder)
             except EnvironmentError as e:
                 logger.critical('{0}'.format(str(e)))
 
         else:
-            logger.warn('Path \'{0}\' already exist.'.format(folder))
+            logger.warning('Path \'{0}\' already exist.'.format(folder))
 
         queue = [(self, url, folder) for url in queue]
 

--- a/nhentai/logger.py
+++ b/nhentai/logger.py
@@ -173,7 +173,7 @@ logger.setLevel(logging.DEBUG)
 if __name__ == '__main__':
     logger.log(15, 'nhentai')
     logger.info('info')
-    logger.warn('warn')
+    logger.warning('warning')
     logger.debug('debug')
     logger.error('error')
     logger.critical('critical')

--- a/nhentai/parser.py
+++ b/nhentai/parser.py
@@ -126,7 +126,7 @@ def doujinshi_parser(id_):
             return doujinshi_parser(str(id_))
 
     except Exception as e:
-        logger.warn('Error: {}, ignored'.format(str(e)))
+        logger.warning('Error: {}, ignored'.format(str(e)))
         return None
 
     html = BeautifulSoup(response, 'html.parser')
@@ -180,7 +180,7 @@ def old_search_parser(keyword, sorting='date', page=1):
 
     result = _get_title_and_id(response)
     if not result:
-        logger.warn('Not found anything of keyword {}'.format(keyword))
+        logger.warning('Not found anything of keyword {}'.format(keyword))
 
     return result
 
@@ -221,7 +221,7 @@ def search_parser(keyword, sorting, page, is_page_all=False):
             break
 
         if 'result' not in response:
-            logger.warn('No result in response in page {}'.format(p))
+            logger.warning('No result in response in page {}'.format(p))
             break
 
         for row in response['result']:
@@ -230,7 +230,7 @@ def search_parser(keyword, sorting, page, is_page_all=False):
             result.append({'id': row['id'], 'title': title})
 
         if not result:
-            logger.warn('No results for keywords {}'.format(keyword))
+            logger.warning('No results for keywords {}'.format(keyword))
 
     return result
 


### PR DESCRIPTION
logger.warn has been deprecated since Python 3.3, the preferred function is now logger.warning.

https://stackoverflow.com/questions/15539937/whats-the-difference-between-logging-warn-and-logging-warning-in-python