### PR TITLE
Fix UnicodeEncodeError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .DS_Store
 output/
 venv/
+.vscode/

--- a/nhentai/serializer.py
+++ b/nhentai/serializer.py
@@ -32,7 +32,7 @@ def serialize_json(doujinshi, dir):
 
 def serialize_comic_xml(doujinshi, dir):
     from iso8601 import parse_date
-    with open(os.path.join(dir, 'ComicInfo.xml'), 'w') as f:
+    with open(os.path.join(dir, 'ComicInfo.xml'), 'w', encoding="utf-8") as f:
         f.write('<?xml version="1.0" encoding="utf-8"?>\n')
         f.write('<ComicInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
                 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')


### PR DESCRIPTION
Don't know why you're taking so long to fix this simple issue, so I made a pull request.
Reference : https://stackoverflow.com/questions/27092833/unicodeencodeerror-charmap-codec-cant-encode-characters

```
Traceback (most recent call last):
  File "c:\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Python39\Scripts\nhentai.exe\__main__.py", line 7, in <module>
  File "c:\python39\lib\site-packages\nhentai\command.py", line 102, in main
    generate_cbz(options.output_dir, doujinshi, options.rm_origin_dir)
  File "c:\python39\lib\site-packages\nhentai\utils.py", line 177, in generate_cbz
    serialize_comicxml(doujinshi_obj, doujinshi_dir)
  File "c:\python39\lib\site-packages\nhentai\serializer.py", line 42, in serialize_comicxml
    xml_write_simple_tag(f, 'Summary', doujinshi.info.subtitle)
  File "c:\python39\lib\site-packages\nhentai\serializer.py", line 75, in xml_write_simple_tag
    f.write('{}<{}>{}</{}>\n'.format(' ' * indent, name, escape(str(val)), name))
  File "c:\python39\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 11-13: character maps to <undefined>
```