### PR TITLE
Adhere to XDG base dir spec on Linux

### DIFF
--- a/nhentai/constant.py
+++ b/nhentai/constant.py
@@ -3,7 +3,22 @@ import os
 import tempfile
 
 from urllib.parse import urlparse
+from platform import system
 
+def get_nhentai_home() -> str:
+    home = os.getenv('HOME', tempfile.gettempdir())
+
+    if system() == 'Linux':
+        xdgdat = os.getenv('XDG_DATA_HOME')
+        if xdgdat and os.path.exists(os.path.join(xdgdat, 'nhentai')):
+            return os.path.join(xdgdat, 'nhentai')
+        if home and os.path.exists(os.path.join(home, '.nhentai')):
+            return os.path.join(home, '.nhentai')
+        if xdgdat:
+            return os.path.join(xdgdat, 'nhentai')
+
+    # Use old default path in other systems
+    return os.path.join(home, '.nhentai')
 
 DEBUG = os.getenv('DEBUG', False)
 BASE_URL = os.getenv('NHENTAI', 'https://nhentai.net')
@@ -21,7 +36,7 @@ FAV_URL = f'{BASE_URL}/favorites/'
 
 IMAGE_URL = f'{urlparse(BASE_URL).scheme}://i.{urlparse(BASE_URL).hostname}/galleries'
 
-NHENTAI_HOME = os.path.join(os.getenv('HOME', tempfile.gettempdir()), '.nhentai')
+NHENTAI_HOME = get_nhentai_home()
 NHENTAI_HISTORY = os.path.join(NHENTAI_HOME, 'history.sqlite3')
 NHENTAI_CONFIG_FILE = os.path.join(NHENTAI_HOME, 'config.json')
 


### PR DESCRIPTION
Sorry, I meant to have this wrapped up within a week, but life got complicated.

If there's still interest, here's a PR to fix #299. I opted not to split the config and SQLite db, since that feels like a separate discussion that shouldn't be bundled here. Tested on my Linux machine, seems to work fine and shouldn't affect users who don't care about the spec. Should be simple to expand the same idea to other OSes if anyone wants to.

I'm open to suggestions/criticisms if you have any, and I should be able to respond quickly this time.