### PR TITLE
Fix gallery search for folders with underscore

### DIFF
--- a/nhentai/viewer/main.js
+++ b/nhentai/viewer/main.js
@@ -139,7 +139,7 @@ function filter_searcher(){
 					break
 			}
 		}
-		if (verifier){doujinshi_id.push(data[i].Folder);}
+		if (verifier){doujinshi_id.push(data[i].Folder.replace("_", " ");}
 	}
 	var gallery = document.getElementsByClassName("gallery-favorite");
 	for (var i = 0; i < gallery.length; i++){


### PR DESCRIPTION
Gallery title names replace '\_' in the folder name with ' ' (`generate_main_html()`). To match against these title names when searching, we must also replace '\_' with ' ' for each folder name we add to the list of titles to unhide.