### PR TITLE
Bug fixes & improve duplicate checks

### DIFF
--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -87,7 +87,9 @@ def main():
 
             if not options.dryrun:
                 doujinshi.downloader = downloader
-                doujinshi.download(regenerate_cbz=options.regenerate_cbz)
+                result = doujinshi.download(regenerate_cbz=options.regenerate_cbz)
+                # Already downloaded; continue on with the other doujins.
+                if not result: continue
 
             if options.generate_metadata:
                 table = doujinshi.table

--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -93,7 +93,15 @@ def main():
 
             if options.generate_metadata:
                 table = doujinshi.table
-                generate_metadata_file(options.output_dir, table, doujinshi)
+
+                # Skip downloading metadata if archived file is already generated.
+                check_file_type = ''
+                if options.is_cbz: check_file_type = '.cbz'
+                elif options.is_pdf: check_file_type = '.pdf'
+
+                result = generate_metadata_file(options.output_dir, table, doujinshi, check_file_type)
+                # Already downloaded; continue on with the other doujins.
+                if not result: continue
 
             if options.is_save_download_history:
                 with DB() as db:

--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -85,21 +85,19 @@ def main():
             else:
                 continue
 
+            file_type = ''
+            if options.is_cbz: file_type = '.cbz'
+            elif options.is_pdf: file_type = '.pdf'
+
             if not options.dryrun:
                 doujinshi.downloader = downloader
-                result = doujinshi.download(regenerate_cbz=options.regenerate_cbz)
+                result = doujinshi.download(regenerate_cbz=options.regenerate_cbz, file_type=file_type)
                 # Already downloaded; continue on with the other doujins.
                 if not result: continue
 
             if options.generate_metadata:
                 table = doujinshi.table
-
-                # Skip downloading metadata if archived file is already generated.
-                check_file_type = ''
-                if options.is_cbz: check_file_type = '.cbz'
-                elif options.is_pdf: check_file_type = '.pdf'
-
-                result = generate_metadata_file(options.output_dir, table, doujinshi, check_file_type)
+                result = generate_metadata_file(options.output_dir, table, doujinshi, file_type)
                 # Already downloaded; continue on with the other doujins.
                 if not result: continue
 

--- a/nhentai/doujinshi.py
+++ b/nhentai/doujinshi.py
@@ -72,7 +72,7 @@ class Doujinshi(object):
     def show(self):
         logger.info(f'Print doujinshi information of {self.id}\n{tabulate(self.table)}')
 
-    def download(self, regenerate_cbz=False):
+    def download(self, regenerate_cbz=False, file_type=''):
         logger.info(f'Starting to download doujinshi: {self.name}')
         if self.downloader:
             download_queue = []
@@ -82,9 +82,10 @@ class Doujinshi(object):
             for i in range(1, min(self.pages, len(self.ext)) + 1):
                 download_queue.append(f'{IMAGE_URL}/{self.img_id}/{i}.{self.ext[i-1]}')
 
-            self.downloader.start_download(download_queue, self.filename, regenerate_cbz=regenerate_cbz)
+            return self.downloader.start_download(download_queue, self.filename, regenerate_cbz=regenerate_cbz, file_type=file_type)
         else:
             logger.critical('Downloader has not been loaded')
+            return False
 
 
 if __name__ == '__main__':

--- a/nhentai/downloader.py
+++ b/nhentai/downloader.py
@@ -115,7 +115,8 @@ class Downloader(Singleton):
 
         return 1, url
 
-    def start_download(self, queue, folder='', regenerate_cbz=False):
+
+    def start_download(self, queue, folder='', regenerate_cbz=False) -> bool:
         if not isinstance(folder, (str, )):
             folder = str(folder)
 
@@ -125,7 +126,7 @@ class Downloader(Singleton):
         if os.path.exists(folder + '.cbz'):
             if not regenerate_cbz:
                 logger.warning(f'CBZ file "{folder}.cbz" exists, ignored download request')
-                return
+                return False
 
         logger.info(f'Doujinshi will be saved at "{folder}"')
         if not os.path.exists(folder):
@@ -138,7 +139,8 @@ class Downloader(Singleton):
             logger.warning(f'Path "{folder}" already exist.')
 
         if os.getenv('DEBUG', None) == 'NODOWNLOAD':
-            return
+            # Assuming we want to continue with rest of process?
+            return True
         queue = [(self, url, folder, constant.CONFIG['proxy']) for url in queue]
 
         pool = multiprocessing.Pool(self.size, init_worker)
@@ -146,6 +148,8 @@ class Downloader(Singleton):
 
         pool.close()
         pool.join()
+
+        return True
 
 
 def download_wrapper(obj, url, folder='', proxy=None):

--- a/nhentai/downloader.py
+++ b/nhentai/downloader.py
@@ -135,9 +135,6 @@ class Downloader(Singleton):
             except EnvironmentError as e:
                 logger.critical(str(e))
 
-        else:
-            logger.warning(f'Path "{folder}" already exist.')
-
         if os.getenv('DEBUG', None) == 'NODOWNLOAD':
             # Assuming we want to continue with rest of process?
             return True

--- a/nhentai/downloader.py
+++ b/nhentai/downloader.py
@@ -57,7 +57,7 @@ class Downloader(Singleton):
         save_file_path = os.path.join(folder, base_filename.zfill(3) + extension)
         try:
             if os.path.exists(save_file_path):
-                logger.warning(f'Ignored exists file: {save_file_path}')
+                logger.warning(f'Skipped download: {save_file_path} already exists')
                 return 1, url
 
             response = None
@@ -116,17 +116,16 @@ class Downloader(Singleton):
         return 1, url
 
 
-    def start_download(self, queue, folder='', regenerate_cbz=False) -> bool:
+    def start_download(self, queue, folder='', regenerate_cbz=False, file_type='') -> bool:
         if not isinstance(folder, (str, )):
             folder = str(folder)
 
         if self.path:
             folder = os.path.join(self.path, folder)
 
-        if os.path.exists(folder + '.cbz'):
-            if not regenerate_cbz:
-                logger.warning(f'CBZ file "{folder}.cbz" exists, ignored download request')
-                return False
+        if file_type != '' and os.path.exists(folder + file_type) and not regenerate_cbz:
+            logger.warning(f'Skipped download: "{folder}{file_type}" already exists')
+            return False
 
         logger.info(f'Doujinshi will be saved at "{folder}"')
         if not os.path.exists(folder):
@@ -136,7 +135,7 @@ class Downloader(Singleton):
                 logger.critical(str(e))
 
         if os.getenv('DEBUG', None) == 'NODOWNLOAD':
-            # Assuming we want to continue with rest of process?
+            # Assuming we want to continue with rest of process.
             return True
         queue = [(self, url, folder, constant.CONFIG['proxy']) for url in queue]
 

--- a/nhentai/utils.py
+++ b/nhentai/utils.py
@@ -237,7 +237,7 @@ def generate_pdf(output_dir='.', doujinshi_obj=None, rm_origin_dir=False, move_t
             logger.info(f'Skipped download: {doujinshi_dir} already exists')
             return
 
-        file_list = os.listdir(doujinshi_dir)
+        file_list = [f for f in os.listdir(doujinshi_dir) if f.lower().endswith(('.png', '.jpg', '.jpeg', '.gif'))]
         file_list.sort()
 
         logger.info(f'Writing PDF file to path: {filename}')


### PR DESCRIPTION
- When using `--meta --cbz` with a duplicated `cbz` file will result in this error.
  - This was caused by the [downloader being skipped](https://github.com/RicterZ/nhentai/blob/dec3f44542d601641f88cf6a642f6d653eaffba6/nhentai/downloader.py#L125-L128), but not [the rest of the process](https://github.com/RicterZ/nhentai/blob/dec3f44542d601641f88cf6a642f6d653eaffba6/nhentai/command.py#L88-L94).
```
File "\?\A:\nhentai.venv\Scripts\nhentai-script.py", line 33, in <module>
    sys.exit(load_entry_point('nhentai==0.5.7', 'console_scripts', 'nhentai')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "A:\nhentai.venv\Lib\site-packages\nhentai-0.5.7-py3.12.egg\nhentai\command.py", line 94, in main
    generate_metadata_file(options.output_dir, table, doujinshi)
  File "A:\nhentai.venv\Lib\site-packages\nhentai-0.5.7-py3.12.egg\nhentai\utils.py", line 313, in generate_metadata_file
    f = open(os.path.join(doujinshi_dir, 'info.txt'), 'w', encoding='utf-8')
```
- Fixes pdf generation reading non-image files (info.txt, ComicInfo.xml)
  - This assumes the only image types are png, jpg, jpeg, and gif from nhentai.
```
Traceback (most recent call last):
  File "A:\nhentai.venv\Lib\site-packages\img2pdf.py", line 1817, in read_images
    imgdata = Image.open(im)
              ^^^^^^^^^^^^^^
  File "A:\nhentai.venv\Lib\site-packages\PIL\Image.py", line 3498, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x0000026F22120720>


Traceback (most recent call last):
  File "\\?\A:\nhentai.venv\Scripts\nhentai-script.py", line 33, in <module>
    sys.exit(load_entry_point('nhentai==0.5.7', 'console_scripts', 'nhentai')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "A:\nhentai.venv\Lib\site-packages\nhentai-0.5.7-py3.12.egg\nhentai\command.py", line 114, in main
    generate_pdf(options.output_dir, doujinshi, options.rm_origin_dir, options.move_to_folder)
  File "A:\nhentai.venv\Lib\site-packages\nhentai-0.5.7-py3.12.egg\nhentai\utils.py", line 243, in generate_pdf
    pdf_f.write(img2pdf.convert(full_path_list, rotation=img2pdf.Rotation.ifvalid))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "A:\nhentai.venv\Lib\site-packages\img2pdf.py", line 2733, in convert
    ) in read_images(
         ^^^^^^^^^^^^
  File "A:\nhentai.venv\Lib\site-packages\img2pdf.py", line 1829, in read_images
    raise ImageOpenError(
img2pdf.ImageOpenError: cannot read input image (not jpeg2000). PIL: error reading image: cannot identify image file <_io.BytesIO object at 0x0000026F22120720>
```
- When a `.cbz` file is already generated, duplicate downloads will be ignored even when the flags are different (i.e. `--pdf` instead of `--cbz`).
   - This was caused by a [hard-coded `.cbz` file extension check](https://github.com/RicterZ/nhentai/blob/dec3f44542d601641f88cf6a642f6d653eaffba6/nhentai/downloader.py#L125-L128).
- De-duped file exists checks into helper method for more consistent behavior.
  - Logger message is done in parent function rather than helper to maintain logger context.
- [Removed warning when folder already exists.](https://github.com/RicterZ/nhentai/blob/dec3f44542d601641f88cf6a642f6d653eaffba6/nhentai/downloader.py#L137-L138)
  - Nothing is wrong with this. Proceed silently.
- Optimized path call in generating filename path at [1](https://github.com/RicterZ/nhentai/blob/b51e812449c7fed53e8dfa0da31a1729f6db7b64/nhentai/utils.py#L176) and [2](https://github.com/RicterZ/nhentai/blob/b51e812449c7fed53e8dfa0da31a1729f6db7b64/nhentai/utils.py#L215-L218)
  - `os.path.join(doujinshi_dir, '..')` was essentially equivalent to `output_dir`

Not sure what the expected behavior [should be here](https://github.com/normalizedwater546/nhentai/blob/a05a308e71f6a6532331128418591343fc622422/nhentai/downloader.py#L137-L139). I assumed this should continue with the rest of the process.