### PR TITLE
Fix some regressions after #343

### DIFF
--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -94,6 +94,7 @@ def main():
                     doujinshi.download()
                 else:
                     logger.info(f'Skip download doujinshi because a PDF/CBZ file exists of doujinshi {doujinshi.name}')
+                    continue
 
             if options.generate_metadata:
                 generate_metadata_file(options.output_dir, doujinshi)

--- a/nhentai/doujinshi.py
+++ b/nhentai/doujinshi.py
@@ -74,26 +74,28 @@ class Doujinshi(object):
 
     def check_if_need_download(self, options):
         base_path = os.path.join(self.downloader.path, self.filename)
+        file_ext = None
 
-        # doujinshi directory is not exist, we need to download definitely
-        if not (os.path.exists(base_path) and os.path.isdir(base_path)):
-            return True
-
-        # regenerate, we need to re-download from nhentai
+        # regenerate, re-download
         if options.regenerate:
             return True
 
+        # detect file extensions
         if options.is_pdf:
             file_ext = 'pdf'
         elif options.is_cbz:
             file_ext = 'cbz'
-        else:
-            # re-download
-            return True
 
-        # pdf or cbz file exists, we needn't to re-download it
-        if os.path.exists(f'{base_path}.{file_ext}') or os.path.exists(f'{base_path}/{self.filename}.{file_ext}'):
-            return False
+        # pdf or cbz file exists, skip re-download
+        # doujinshi directory may not exist b/c of --rm-origin-dir option set.
+        # user should pass --regenerate option to get back origin dir.
+        if file_ext is not None:
+            if os.path.exists(f'{base_path}.{file_ext}') or os.path.exists(f'{base_path}/{self.filename}.{file_ext}'):
+                return False
+
+        # doujinshi directory doesn't exist, re-download
+        if not (os.path.exists(base_path) and os.path.isdir(base_path)):
+            return True
 
         # fallback
         return True


### PR DESCRIPTION
## regression: pdf/cbz file already exists, but origin files are downloaded anyways.
- user should just pass `--regenerate` option to get back origin dir.
```
(.venv) PS G:\Exports\nhentai> nhentai --id 405076 --download --format '%t [%i]' --threads=4 --cbz --pdf --meta --output="test-output" --no-html --rm-origin-dir
[21:29:26] banner: nHentai ver 0.5.9: あなたも変態。 いいね?
[21:29:26] main: Using mirror: https://nhentai.net
[21:29:26] main: Using viewer template "default"
[21:29:26] check_cookie: Login successfully! Your username: ****
[21:29:26] doujinshi_parser: Fetching doujinshi information of id 405076
[21:29:27] start_download: Doujinshi will be saved at "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076]"
[21:29:28] download: Starting to download https://i.nhentai.net/galleries/2234228/1.jpg ...
...
[21:29:33] download: Starting to download https://i.nhentai.net/galleries/2234228/9.jpg ...
[21:29:35] generate_metadata_file: Metadata Info has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076]\info.txt"
[21:29:35] generate_doc: Writing CBZ file to path: test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].cbz
[21:29:35] generate_doc: Comic Book CBZ file has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].cbz"
[21:29:35] generate_doc: Writing PDF file to path: test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].pdf
[21:29:35] generate_doc: PDF file has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].pdf"
[21:29:35] main: All done.
(.venv) PS G:\Exports\nhentai> nhentai --id 405076 --download --format '%t [%i]' --threads=4 --cbz --pdf --meta --output="test-output" --no-html --rm-origin-dir
[21:29:38] banner: nHentai ver 0.5.9: あなたも変態。 いいね?
[21:29:38] main: Using mirror: https://nhentai.net
[21:29:38] main: Using viewer template "default"
[21:29:38] check_cookie: Login successfully! Your username: ****
[21:29:38] doujinshi_parser: Fetching doujinshi information of id 405076
[21:29:39] download: Starting to download doujinshi: [Poriuretan] Angai Noriki na Ko | A Surprisingly Cooperative Girl [English]
[21:29:39] start_download: Doujinshi will be saved at "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076]"
[21:29:41] download: Starting to download https://i.nhentai.net/galleries/2234228/1.jpg ...
...
[21:29:45] download: Starting to download https://i.nhentai.net/galleries/2234228/9.jpg ...
[21:29:47] generate_metadata_file: Metadata Info has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076]\info.txt"
[21:29:48] generate_doc: Writing CBZ file to path: test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].cbz
[21:29:48] generate_doc: Comic Book CBZ file has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].cbz"
[21:29:48] generate_doc: Writing PDF file to path: test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].pdf
[21:29:48] generate_doc: PDF file has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].pdf"
[21:29:48] main: All done.
```

## fix: pdf/cbz file already exists, but download process continues
```
(.venv) PS G:\Exports\nhentai> nhentai --id 405076 --download --format '%t [%i]' --threads=4 --cbz --pdf --meta --output="test-output" --no-html --rm-origin-dir
[21:27:28] banner: nHentai ver 0.5.9: あなたも変態。 いいね?
[21:27:28] main: Using mirror: https://nhentai.net
[21:27:28] main: Using viewer template "default"
[21:27:29] check_cookie: Login successfully! Your username: ****
[21:27:29] doujinshi_parser: Fetching doujinshi information of id 405076
[21:27:30] start_download: Doujinshi will be saved at "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076]"
[21:27:31] download: Starting to download https://i.nhentai.net/galleries/2234228/1.jpg ...
...
[21:27:34] download: Starting to download https://i.nhentai.net/galleries/2234228/9.jpg ...
[21:27:35] generate_metadata_file: Metadata Info has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076]\info.txt"
[21:27:35] generate_doc: Writing CBZ file to path: test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].cbz
[21:27:35] generate_doc: Comic Book CBZ file has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].cbz"
[21:27:35] generate_doc: Writing PDF file to path: test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].pdf
[21:27:35] generate_doc: PDF file has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].pdf"
[21:27:35] main: All done.
(.venv) PS G:\Exports\nhentai> nhentai --id 405076 --download --format '%t [%i]' --threads=4 --cbz --pdf --meta --output="test-output" --no-html --rm-origin-dir
[21:27:41] banner: nHentai ver 0.5.9: あなたも変態。 いいね?
[21:27:41] main: Using mirror: https://nhentai.net
[21:27:41] main: Using viewer template "default"
[21:27:42] check_cookie: Login successfully! Your username: ****
[21:27:42] doujinshi_parser: Fetching doujinshi information of id 405076
[21:27:42] main: Skip download doujinshi because a PDF/CBZ file exists of doujinshi [Poriuretan] Angai Noriki na Ko | A Surprisingly Cooperative Girl [English]
Traceback (most recent call last):
  File "\\?\G:\Exports\.venv\Scripts\nhentai-script.py", line 33, in <module>
    sys.exit(load_entry_point('nhentai==0.5.9', 'console_scripts', 'nhentai')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "G:\Exports\.venv\Lib\site-packages\nhentai-0.5.9-py3.12.egg\nhentai\command.py", line 99, in main
    generate_metadata_file(options.output_dir, doujinshi)
  File "G:\Exports\.venv\Lib\site-packages\nhentai-0.5.9-py3.12.egg\nhentai\utils.py", line 306, in generate_metadata_file
    f = open(info_txt_path, 'w', encoding='utf-8')
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'test-output\\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076]\\info.txt'
```

## after fix logs
```
(.venv) PS G:\Exports\nhentai> nhentai --id 405076 --download --format '%t [%i]' --threads=4 --cbz --pdf --meta --output="test-output" --no-html --rm-origin-dir
[21:38:05] banner: nHentai ver 0.5.9: あなたも変態。 いいね?
[21:38:05] main: Using mirror: https://nhentai.net
[21:38:05] main: Using viewer template "default"
[21:38:06] check_cookie: Login successfully! Your username: ****
[21:38:06] doujinshi_parser: Fetching doujinshi information of id 405076
[21:38:07] start_download: Doujinshi will be saved at "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076]"
[21:38:08] download: Starting to download https://i.nhentai.net/galleries/2234228/1.jpg ...
...
[21:38:10] download: Starting to download https://i.nhentai.net/galleries/2234228/9.jpg ...
[21:38:11] generate_metadata_file: Metadata Info has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076]\info.txt"
[21:38:11] generate_doc: Writing CBZ file to path: test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].cbz
[21:38:11] generate_doc: Comic Book CBZ file has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].cbz"
[21:38:11] generate_doc: Writing PDF file to path: test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].pdf
[21:38:11] generate_doc: PDF file has been written to "test-output\[Poriuretan] Angai Noriki na Ko A Surprisingly Cooperative Girl [English] [405076].pdf"
[21:38:11] main: All done.
(.venv) PS G:\Exports\nhentai> nhentai --id 405076 --download --format '%t [%i]' --threads=4 --cbz --pdf --meta --output="test-output" --no-html --rm-origin-dir
[21:38:16] banner: nHentai ver 0.5.9: あなたも変態。 いいね?
[21:38:16] main: Using mirror: https://nhentai.net
[21:38:16] main: Using viewer template "default"
[21:38:16] check_cookie: Login successfully! Your username: ****
[21:38:16] doujinshi_parser: Fetching doujinshi information of id 405076
[21:38:17] main: Skip download doujinshi because a PDF/CBZ file exists of doujinshi [Poriuretan] Angai Noriki na Ko | A Surprisingly Cooperative Girl [English]
[21:38:17] main: All done.
```