### PR TITLE
asyncio: fix downloader being run sequentially + httpx: fix proxy and missing headers

### DIFF
--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -77,7 +77,7 @@ def main():
         doujinshi_ids = list(set(map(int, doujinshi_ids)) - set(data))
 
     if not options.is_show:
-        downloader = Downloader(path=options.output_dir, size=options.threads,
+        downloader = Downloader(path=options.output_dir, threads=options.threads,
                                 timeout=options.timeout, delay=options.delay)
 
         for doujinshi_id in doujinshi_ids:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -20,7 +20,7 @@ class TestDownload(unittest.TestCase):
     def test_download(self):
         did = 440546
         info = Doujinshi(**doujinshi_parser(did), name_format='%i')
-        info.downloader = Downloader(path='/tmp', size=5)
+        info.downloader = Downloader(path='/tmp', threads=5)
         info.download()
 
         self.assertTrue(os.path.exists(f'/tmp/{did}/001.jpg'))


### PR DESCRIPTION
This bug is a regression caused by https://github.com/RicterZ/nhentai/pull/351

## Changes
- The threads (renamed from size) argument was ignored, thus code was running sequentially
- Changed to `asyncio.sleep`, since `time.sleep` is blocking.
- Cleaned up dead code from multiprocessing library
- Fix httpx requests not using headers/proxy

## Command
`nhentai --id 405076 --download --format '%t [%i]' --threads=4 --output="output-1" --delay 1`

## Before
![image](https://github.com/user-attachments/assets/61efdf00-9621-46af-843a-6459fa34b191)

## After
![image](https://github.com/user-attachments/assets/6006cb41-bec3-44e2-a18c-5f9da9fdb0c6)
