### PR TITLE
Fix none attributes in session headers

### DIFF
--- a/nhentai/utils.py
+++ b/nhentai/utils.py
@@ -20,14 +20,24 @@ from nhentai.serializer import serialize_comic_xml, serialize_json, serialize_in
 MAX_FIELD_LENGTH = 100
 EXTENSIONS = ('.png', '.jpg', '.jpeg', '.gif', '.webp')
 
+def get_headers():
+    headers = {
+        'Referer': constant.LOGIN_URL
+    }
+
+    user_agent = constant.CONFIG.get('useragent')
+    if user_agent and user_agent.strip():
+        headers['User-Agent'] = user_agent
+
+    cookie = constant.CONFIG.get('cookie')
+    if cookie and cookie.strip():
+        headers['Cookie'] = cookie
+
+    return headers
 
 def request(method, url, **kwargs):
     session = requests.Session()
-    session.headers.update({
-        'Referer': constant.LOGIN_URL,
-        'User-Agent': constant.CONFIG['useragent'],
-        'Cookie': constant.CONFIG['cookie']
-    })
+    session.headers.update(get_headers())
 
     if not kwargs.get('proxies', None):
         kwargs['proxies'] = {
@@ -39,11 +49,7 @@ def request(method, url, **kwargs):
 
 
 async def async_request(method, url, proxy = None, **kwargs):
-    headers = {
-        'Referer': constant.LOGIN_URL,
-        'User-Agent': constant.CONFIG['useragent'],
-        'Cookie': constant.CONFIG['cookie'],
-    }
+    headers=get_headers()
 
     if proxy is None:
         proxy = constant.CONFIG['proxy']


### PR DESCRIPTION
If user-agent or cookie is not defined in shell environment, the dict headers will receive None value, and finally raise AttributeError.

call stack is in here:
```
  File "nhentai/test_download.py", line 33, in <module>
    unittest.main()
  File "/usr/lib/python3.11/unittest/main.py", line 102, in __init__
    self.runTests()
  File "/usr/lib/python3.11/unittest/main.py", line 274, in runTests
    self.result = testRunner.run(self.test)
  File "/usr/lib/python3.11/unittest/runner.py", line 217, in run
    test(result)
  File "/usr/lib/python3.11/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.11/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.11/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.11/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.11/unittest/case.py", line 678, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
  File "/home/archetto/project/nhentai/test_download.py", line 24, in test_download
    info.download()
  File "/home/archetto/project/nhentai/nhentai/doujinshi.py", line 120, in download
    return self.downloader.start_download(download_queue, self.filename)
  File "/home/archetto/project/nhentai/nhentai/downloader.py", line 165, in start_download
    asyncio.run(self.fiber(coroutines))
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/usr/lib/python3.11/asyncio/base_events.py", line 640, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.11/asyncio/base_events.py", line 607, in run_forever
    self._run_once()
  File "/usr/lib/python3.11/asyncio/base_events.py", line 1922, in _run_once
    handle._run()
  File "/usr/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/home/archetto/project/nhentai/nhentai/downloader.py", line 61, in _semaphore_download
    return await self.download(*args, **kwargs)
  File "/home/archetto/project/nhentai/nhentai/downloader.py", line 111, in download
    traceback.print_stack()
[15:38:10] download: 'NoneType' object has no attribute 'encode'
```