### PR TITLE
Add support for exporting as a table

### DIFF
--- a/nhentai/cmdline.py
+++ b/nhentai/cmdline.py
@@ -72,6 +72,9 @@ def cmd_parser():
                         help='download doujinshi (for search results)')
     parser.add_argument('--show', '-S', dest='is_show', action='store_true',
                         help='just show the doujinshi information')
+    parser.add_argument('--export-table', dest='table', type=str,
+                        help='export the doujinshi info to a tsv (Tab Seperated Values) file')
+
 
     # doujinshi options
     parser.add_argument('--id', dest='id', nargs='+', type=int,
@@ -196,6 +199,17 @@ def cmd_parser():
 
         logger.info('Download history cleaned.')
         sys.exit(0)
+
+    #TODO: not hardcode this?
+    if args.table:
+         try:
+             open(args.table,'w')
+         except:
+             logger.error(f'Path \'{args.table}\' is invalid')
+             sys.exit(1)
+
+         logger.info(f'using file {args.table}')
+
 
     # --- set config ---
     if args.cookie is not None:

--- a/nhentai/command.py
+++ b/nhentai/command.py
@@ -8,7 +8,7 @@ import urllib3.exceptions
 
 from nhentai import constant
 from nhentai.cmdline import cmd_parser, banner, write_config
-from nhentai.parser import doujinshi_parser, search_parser, legacy_search_parser, print_doujinshi, favorites_parser
+from nhentai.parser import doujinshi_parser, search_parser, legacy_search_parser, print_doujinshi, export_doujinshi, favorites_parser
 from nhentai.doujinshi import Doujinshi
 from nhentai.downloader import Downloader, CompressedDownloader
 from nhentai.logger import logger
@@ -52,11 +52,21 @@ def main():
     if options.retry:
         constant.RETRY_TIMES = int(options.retry)
 
+    # NOTE: for exporting properly, not abridge titles
+    shorten = True
+    if options.table:
+        shorten = False
+
     if options.favorites:
         if not options.is_download:
             logger.warning('You do not specify --download option')
 
-        doujinshis = favorites_parser(page=page_list) if options.page else favorites_parser()
+
+
+        if options.page:
+            doujinshis = favorites_parser(page=page_list,is_shorten=shorten)
+        else:
+            doujinshis = favorites_parser(is_shorten=shorten)
 
     elif options.keyword:
         if constant.CONFIG['language']:
@@ -65,16 +75,21 @@ def main():
 
         _search_parser = legacy_search_parser if options.legacy else search_parser
         doujinshis = _search_parser(options.keyword, sorting=options.sorting, page=page_list,
-                                    is_page_all=options.page_all)
+                                    is_page_all=options.page_all,is_shorten=shorten)
 
     elif options.artist:
         doujinshis = legacy_search_parser(options.artist, sorting=options.sorting, page=page_list,
-                                          is_page_all=options.page_all, type_='ARTIST')
+                                          is_page_all=options.page_all, type_='ARTIST',is_shorten=shorten)
 
     elif not doujinshi_ids:
         doujinshi_ids = options.id
 
     print_doujinshi(doujinshis)
+
+    if options.table:
+        logger.info(f'Exporting to file {options.table} as requested')
+        export_doujinshi(doujinshis, options.table)
+
     if options.is_download and doujinshis:
         doujinshi_ids = [i['id'] for i in doujinshis]
 

--- a/nhentai/parser.py
+++ b/nhentai/parser.py
@@ -65,7 +65,7 @@ def _get_title_and_id(response,is_shorten_title=True):
     return result
 
 
-def favorites_parser(page=None):
+def favorites_parser(page=None,is_shorten=True):
     result = []
     html = BeautifulSoup(request('get', constant.FAV_URL).content, 'html.parser')
     count = html.find('span', attrs={'class': 'count'})
@@ -106,7 +106,7 @@ def favorites_parser(page=None):
 
             try:
                 resp = request('get', f'{constant.FAV_URL}?page={page}').content
-                temp_result = _get_title_and_id(resp)
+                temp_result = _get_title_and_id(resp,is_shorten_title=is_shorten)
                 if not temp_result:
                     logger.warning(f'Failed to get favorites at page {page}, retrying ({i} times) ...')
                     continue
@@ -219,7 +219,20 @@ def print_doujinshi(doujinshi_list):
     print(tabulate(tabular_data=doujinshi_list, headers=headers, tablefmt='rst'))
 
 
-def legacy_search_parser(keyword, sorting, page, is_page_all=False, type_='SEARCH'):
+def export_doujinshi(doujinshi_list,output_file):
+    #TODO: prevent the duplication of above?
+    doujinshi_list = [(i['id'], i['title']) for i in doujinshi_list]
+    headers = ['id', 'doujinshi']
+
+    data = tabulate(tabular_data=doujinshi_list,headers=headers,tablefmt='rst')
+
+    logger.info(f"Saving to file {output_file}")
+
+    with open(output_file, "w") as f:
+        f.write(data)
+    return
+
+def legacy_search_parser(keyword, sorting, page, is_page_all=False, type_='SEARCH', is_shorten=True):
     logger.info(f'Searching doujinshis of keyword {keyword}')
     result = []
 
@@ -255,7 +268,7 @@ def legacy_search_parser(keyword, sorting, page, is_page_all=False, type_='SEARC
         if response is None:
             logger.warning(f'No result in response in page {p}')
             continue
-        result.extend(_get_title_and_id(response))
+        result.extend(_get_title_and_id(response,is_shorten_title=is_shorten))
 
     if not result:
         logger.warning(f'No results for keywords {keyword}')
@@ -263,7 +276,7 @@ def legacy_search_parser(keyword, sorting, page, is_page_all=False, type_='SEARC
     return result
 
 
-def search_parser(keyword, sorting, page, is_page_all=False):
+def search_parser(keyword, sorting, page, is_page_all=False, is_shorten=True):
     result = []
     response = None
     if not page:
@@ -305,8 +318,10 @@ def search_parser(keyword, sorting, page, is_page_all=False):
 
         for row in response['result']:
             title = row['title']['english']
-            title = title[:constant.CONFIG['max_filename']] + '..' if \
-                len(title) > constant.CONFIG['max_filename'] else title
+
+            if(is_shorten):
+                title = title[:constant.CONFIG['max_filename']] + '..' if \
+                    len(title) > constant.CONFIG['max_filename'] else title
 
             result.append({'id': row['id'], 'title': title})
 

--- a/nhentai/parser.py
+++ b/nhentai/parser.py
@@ -48,14 +48,17 @@ def login(username, password):
         sys.exit(2)
 
 
-def _get_title_and_id(response):
+def _get_title_and_id(response,is_shorten_title=True):
     result = []
     html = BeautifulSoup(response, 'html.parser')
     doujinshi_search_result = html.find_all('div', attrs={'class': 'gallery'})
     for doujinshi in doujinshi_search_result:
         doujinshi_container = doujinshi.find('div', attrs={'class': 'caption'})
         title = doujinshi_container.text.strip()
-        title = title if len(title) < 85 else title[:82] + '...'
+
+        if( is_shorten_title ):
+            title = title if len(title) < 85 else title[:82] + '...'
+
         id_ = re.search('/g/([0-9]+)/', doujinshi.a['href']).group(1)
         result.append({'id': id_, 'title': title})
 


### PR DESCRIPTION
I've tweaked the source to allow the --export-table TABLE argument that will unshorten names and export doujinshi list to a table.

I tested with favorites, artist and search.

Some places are a bit improvised and it could be cleaner but I wanted this feature even if it's a bit DIY.

Any suggestions appreciated.